### PR TITLE
Bugfixes precipitation driven sowing date calculation

### DIFF
--- a/landmanager/components/management/crop_calendar/world.py
+++ b/landmanager/components/management/crop_calendar/world.py
@@ -1207,9 +1207,9 @@ def calc_doy_wet_month(daily_ppet):
     kernel = np.ones(window_size)
 
     # Perform convolution with periodic wrapping
-    extended_values = np.hstack([daily_values, daily_values[:, : window_size - 1]])
+    extended_values = np.hstack([daily_values, daily_values[:, : window_size - 1]])  # noqa
     running_sum = np.apply_along_axis(
-        lambda x: np.convolve(x, kernel, mode="valid"), axis=1, arr=extended_values
+        lambda x: np.convolve(x, kernel, mode="valid"), axis=1, arr=extended_values  # noqa
     )
 
     # Trim the running sum to match the original data length (365 days)

--- a/landmanager/components/management/crop_calendar/world.py
+++ b/landmanager/components/management/crop_calendar/world.py
@@ -1207,7 +1207,7 @@ def calc_doy_wet_month(daily_ppet):
     kernel = np.ones(window_size)
 
     # Perform convolution with periodic wrapping
-    extended_values = np.hstack([daily_values, daily_values[:, :window_size - 1]])
+    extended_values = np.hstack([daily_values, daily_values[:, : window_size - 1]])
     running_sum = np.apply_along_axis(
         lambda x: np.convolve(x, kernel, mode="valid"), axis=1, arr=extended_values
     )


### PR DESCRIPTION
This PR fixes calculations in `calc_doy_wet_month ` by correctly calculating the cumulative sum of the daily precipitation to potential evapotranspiration ratio for 120.
Issues fixed:
* Corrected slicing to account for the two dimensions  of the precipitation to potential evapotranspiration ratio array.
* Introduced period use of values to calculate cumulative sums for the entire year.