### PR TITLE
Separate initialisation of rainfed and irrigated harvest dates

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'models build around LPJmL based on the copan:LPJmL modeling framework'
-version: 0.1.4
+version: 0.1.5
 date-released: '2025-04-11'
 abstract: x
 authors:

--- a/landmanager/components/management/crop_calendar/world.py
+++ b/landmanager/components/management/crop_calendar/world.py
@@ -594,8 +594,10 @@ class WorldCrop(WorldActivity):
 
         # Precompute max temperature once
         max_temp = monthly_climate["max_temp"]
-        hdate_rf = hdate_ir = xr.full_like(self.world.grid.cell, 0, dtype=int)
-        hreason_rf = hreason_ir = xr.full_like(self.world.grid.cell, "", dtype="<U20")  # noqa
+        hdate_rf  = xr.full_like(self.world.grid.cell, 0, dtype=int)
+        hdate_ir = xr.full_like(self.world.grid.cell, 0, dtype=int)
+        hreason_rf = xr.full_like(self.world.grid.cell, "", dtype="<U20")  # noqa
+        hreason_ir = xr.full_like(self.world.grid.cell, "", dtype="<U20")  # noqa
 
         hdate_rf.values = np.select(
             [
@@ -623,7 +625,7 @@ class WorldCrop(WorldActivity):
                 hdate_first,
                 np.where(
                     (smonth == 0) & (max_temp < self.temp_fall),
-                    hdate_temp_opt,
+                    hdate_first,
                     np.minimum(np.maximum(hdate_first, hdate_temp_base), hdate_last),  # noqa
                 ),
                 np.minimum(np.maximum(hdate_first, hdate_temp_opt), hdate_last),  # noqa

--- a/landmanager/components/management/crop_calendar/world.py
+++ b/landmanager/components/management/crop_calendar/world.py
@@ -680,7 +680,7 @@ class WorldCrop(WorldActivity):
                 hdate_first,
                 np.where(
                     (smonth == 0) & (max_temp < self.temp_fall),
-                    hdate_temp_opt,
+                    hdate_first,
                     np.minimum(np.maximum(hdate_first, hdate_temp_base), hdate_last),  # noqa
                 ),
                 np.minimum(np.maximum(hdate_first, hdate_temp_opt), hdate_last),  # noqa

--- a/landmanager/components/management/crop_calendar/world.py
+++ b/landmanager/components/management/crop_calendar/world.py
@@ -594,7 +594,7 @@ class WorldCrop(WorldActivity):
 
         # Precompute max temperature once
         max_temp = monthly_climate["max_temp"]
-        hdate_rf  = xr.full_like(self.world.grid.cell, 0, dtype=int)
+        hdate_rf = xr.full_like(self.world.grid.cell, 0, dtype=int)
         hdate_ir = xr.full_like(self.world.grid.cell, 0, dtype=int)
         hreason_rf = xr.full_like(self.world.grid.cell, "", dtype="<U20")  # noqa
         hreason_ir = xr.full_like(self.world.grid.cell, "", dtype="<U20")  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "landmanager"
-version = "0.1.4"
+version = "0.1.5"
 description = "Models build around LPJmL based on the copan:LPJmL modeling framework"
 readme = "README.md"
 license = {file = "LICENSE.md"}


### PR DESCRIPTION
Fixing an issue that rainfed and irrigated harvest date structures where initialized simultaneously sharing the same memory address. 